### PR TITLE
Change USAboundaries title and link; on CRAN

### DIFF
--- a/packages/index.html
+++ b/packages/index.html
@@ -247,9 +247,9 @@ title: "rOpenSci - Packages"
          <td><span class="label label-nocran">cran</span> <a href="https://github.com/ropensci/historydata/"><span class="label label-inverse">github</span></a></td>
         </tr>
         <tr>
-         <td><a href="https://github.com/ropensci/usboundaries">usboundaries</a></td>
-         <td>Historical boundaries of the United States. Map the United States (or the colonies that became the United States) on any date from 1629 to 2000. Contains both county and state/territory level polygons. <span class="label label-info"> In early development</span></td>
-         <td><span class="label label-nocran">cran</span> <a href="https://github.com/ropensci/usboundaries/"><span class="label label-inverse">github</span></a></td>
+         <td><a href="https://github.com/ropensci/usaboundaries">USAboundaries</a></td>
+         <td>Historical boundaries of the United States. Map the United States (or the colonies that became the United States) on any date from 1629 to 2000. Contains both county and state/territory level polygons.</td>
+         <td><span class="label label-success">cran</span> <a href="https://github.com/ropensci/usaboundaries/"><span class="label label-inverse">github</span></a></td>
         </tr>
     </tbody>
   </table>


### PR DESCRIPTION
The USAboundaries package is now on CRAN, but CRAN maintainers required a change of title. This pull request fixes the title and the URLs to GitHub, and turns on the CRAN badge.
