### PR TITLE
Add link to onboarding repo from packages page

### DIFF
--- a/packages/index.html
+++ b/packages/index.html
@@ -10,6 +10,7 @@ title: "rOpenSci - Packages"
 
     <h2>rOpenSci packages</h2>
      <p>This is a complete list of all available rOpenSci packages. Packages are grouped by ones that acquire <a href="#data_access">data</a>, <a href="#literature">full-text of journal articles</a>, <a href="#altmetrics">altmetrics</a>, <a href="#data_publication">data-publication</a>, focus on <a href="#scalereprod">scalable and reproducibile computing</a>, <a href="#data_viz">data visualization</a>, or <a href="#geospatial">geospatial</a> work. Packages with a <span class="label label-success">cran</span> sign are stable versions that you can quickly install from your nearest mirror using <code>install.packages("PACKAGE_NAME")</code>. Others are in various stages of development (bleeding edge packages are not listed here) and you can learn more by following our <a href="https://github.com/ropensci" title="rOpenSci · GitHub">GitHub organization page</a>, and our <a href="https://github.com/ropenscilabs" title="rOpenSciLabs · GitHub">GitHub organization for bleeding edge projects</a>. All of our software packages are open source. Please see package description files for more information on specific licenses. We also have a <a href="http://status.ropensci.org/" title="rOpenSci package status">package status dashboard</a> that updates periodically. </p>
+     <p>Many of our packages are community-contributed.  If you are interested in contributing a package, please visit our <a href="https://github.com/ropensci/onboarding">onboarding repository</a> for details.</p>
 
 <br>
 


### PR DESCRIPTION
Just adding a bit of text and a link to send people to the onboarding repository from the packages page.  Note that the site is not re-compiled with this change.