### PR TITLE
Change rebi to europepmc in packages listing

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -267,7 +267,7 @@ title: "rOpenSci Community"
                     </div>
                     <div class="info">
                         <div class="name">Nanko Jahn</div>
-                     Najko works at the Bielefeld University Library. Najko maintains <a href="https://github.com/ropensci/rebi">rebi</a>
+                     Najko works at the Bielefeld University Library. Najko maintains <a href="https://github.com/ropensci/europepmc">europepmc</a>
                     </div>
                 </div>
             </div>

--- a/packages/index.html
+++ b/packages/index.html
@@ -429,9 +429,9 @@ title: "rOpenSci - Packages"
         <td><a href="http://cran.rstudio.com/web/packages/rdatacite"><span class="label label-success">cran</span></a> <a href="https://github.com/ropensci/rdatacite/"><span class="label label-inverse">github</span></a></td>
       </tr>
       <tr>
-        <td><a href="https://github.com/ropensci/rebi" id="rebi">rebi</a></td>
+        <td><a href="https://github.com/ropensci/europepmc" id="europepmc">europepmc</a></td>
         <td>Access to the European PubMed Central database of papers and metadata</td>
-        <td><span class="label label-nocran">cran</span> <a href="https://github.com/ropensci/rebi/"><span class="label label-inverse">github</span></a>  </td>
+        <td><span class="label label-nocran">cran</span> <a href="https://github.com/ropensci/europepmc/"><span class="label label-inverse">github</span></a>  </td>
       </tr>
       <!-- <tr>
         <td><a href="https://github.com/ropensci/rmetadata" id="rmetadata">rmetadata</a></td>


### PR DESCRIPTION
The package name has changed in its revision, so just populating the change forward.