### PR TITLE
Update link in blog post

### DIFF
--- a/_posts/2015-06-03-baad.md
+++ b/_posts/2015-06-03-baad.md
@@ -146,7 +146,7 @@ We hope that BAAD will continue to grow.  To that end, we have written a very sm
 
 ```r
 library(baad.data)
-x <- baad_data("ecology")
+x <- baad_data("1.0.0")
 ```
 to download the version stored in Ecological Archives, or
 


### PR DESCRIPTION
Old link was deprecated, now only using version numbers.