### PR TITLE
use newer blogpost examples in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,8 +6,8 @@ To submit any changes to the [rOpenSci website](http://ropensci.org), please for
 If we've asked for an invited blog post, write your post as `.md` or if it contains R examples as `.Rmd` and render the file to the [`_posts`](https://github.com/ropensci/roweb/tree/master/_posts) folder.
 
 Then add appropriate `yml` to your post, including `authorurl` if you are not a core member of the rOpenSci team.
-- [example 1](https://github.com/ropensci/roweb/blob/master/_posts/2014-06-09-reproducibility.md)
--  [example 2](https://github.com/ropensci/roweb/blob/master/_posts/2014-08-15-open-tree-of-life-hackathon.md)
+- [example 1](https://github.com/ropensci/roweb/blob/master/_posts/2017-08-15-magick-10.md)
+-  [example 2](https://github.com/ropensci/roweb/blob/master/_posts/2017-06-23-community.md)
 
 Your `yml` should include the following information (the date format can be
 generated in r `format(Sys.time(), "%Y-%m-%d")`):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Given some changes to yaml format for blog posts (e.g. post-discourse), I added two newer blog posts as examples so that guest bloggers can mimic these

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Blog post?
<!--- If you're doing a guest blog post on our blog:
- if it's all text, and no code, put your post in a `.md` file in
the `_drafts` folder. If you're doing text and code, put it in a
`.Rmd` file and render it as well, so the PR has both `.Rmd`
and `.md` versions of your post.
- See https://raw.githubusercontent.com/ropensci/roweb/master/_posts/2017-04-11-assertr.md
to copy and paste the yaml header we use - changing to your details
of course. Please include a link for you (e.g., your website or
GitHub profile) in the "url" field.
-->
