### PR TITLE
fixed broken patentsview link

### DIFF
--- a/packages/index.html
+++ b/packages/index.html
@@ -236,7 +236,7 @@ title: "rOpenSci - Packages"
         <td><a href="https://cran.rstudio.com/web/packages/nneo/"><span class="label label-success">cran</span></a> <a href="https://github.com/ropenscilabs/nneo"><span class="label label-inverse">github</span></a></td>
       </tr>
       <tr>
-        <td><a href="https://github.com/ropenscilabs/patentsview" id="patentsview">patentsview</a></td>
+        <td><a href="https://github.com/ropensci/patentsview" id="patentsview">patentsview</a></td>
         <td>Provides functions to simplify the PatentsView API <a href="http://www.patentsview.org/api/doc.html">http://www.patentsview.org/api/doc.html</a> query language</td>
         <td><a href="https://cran.rstudio.com/web/packages/patentsview/"><span class="label label-success">cran</span></a> <a href="https://github.com/ropenscilabs/patentsview"><span class="label label-inverse">github</span></a></td>
       </tr>


### PR DESCRIPTION
Scott, let me know if this is helpful or if I should do another way in future.

## Description

Replaced broken link https://github.com/ropenscilabs/patentsview 
with
https://github.com/ropensci/patentsview/
in `roweb/packages/index.html`

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Blog post?
<!--- If you're doing a guest blog post on our blog:
- if it's all text, and no code, put your post in a `.md` file in
the `_drafts` folder. If you're doing text and code, put it in a
`.Rmd` file and render it as well, so the PR has both `.Rmd`
and `.md` versions of your post.
- See https://raw.githubusercontent.com/ropensci/roweb/master/_posts/2017-04-11-assertr.md
to copy and paste the yaml header we use - changing to your details
of course. Please include a link for you (e.g., your website or
GitHub profile) in the "url" field.
-->
